### PR TITLE
Make "How to get" centered on narrow screen.

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -77,19 +77,19 @@
     <section id="how-to-get-section" class="py-16 bg-gray-50">
       <div class="container mx-auto px-4">
         <h2 class="text-3xl font-bold text-center mb-8">How to Get</h2>
-        <div class="flex flex-col md:flex-row justify-center gap-6 text-center">
-          <a href="https://marketplace.visualstudio.com/items?itemName=SSW-JKU.javawiz" class="bg-blue-600 text-white px-8 py-4 rounded-lg hover:bg-blue-500 transition flex flex-col items-center w-72">
+        <div class="flex flex-col md:flex-row justify-center items-center gap-6 text-center">
+          <a href="https://marketplace.visualstudio.com/items?itemName=SSW-JKU.javawiz" class="bg-blue-600 text-white px-8 py-4 rounded-lg hover:bg-blue-500 transition flex flex-col items-center w-72 mx-auto md:mx-0">
             <!-- https://code.visualstudio.com/assets/images/code-stable.png -->
             <img src="https://code.visualstudio.com/assets/images/code-stable-white.png" alt="VS Code Logo" class="h-8 mb-2" />
             <span class="font-bold">Install JavaWiz</span>
             <span class="">Visual Studio Code Extension</span>
           </a>
-          <a href="#how-to-get-section" class="bg-blue-600 text-white px-8 py-4 rounded-lg hover:bg-blue-500 transition flex flex-col items-center w-72">
+          <a href="#how-to-get-section" class="bg-blue-600 text-white px-8 py-4 rounded-lg hover:bg-blue-500 transition flex flex-col items-center w-72 mx-auto md:mx-0">
             <img src="https://resources.jetbrains.com/storage/products/company/brand/logos/IntelliJ_IDEA_icon.png" alt="IntelliJ Logo" class="h-8 mb-2" />
             <span class="font-bold italic">Install JavaWiz</span>
             <span class="italic">Coming Soon: IntelliJ Plugin</span>
           </a>
-          <a href="https://github.com/SSW-JKU/javawiz" class="bg-gray-800 text-white px-8 py-4 rounded-lg hover:bg-gray-700 transition flex flex-col items-center w-72">
+          <a href="https://github.com/SSW-JKU/javawiz" class="bg-gray-800 text-white px-8 py-4 rounded-lg hover:bg-gray-700 transition flex flex-col items-center w-72 mx-auto md:mx-0">
             <img src="https://github.githubassets.com/assets/GitHub-Mark-ea2971cee799.png" alt="GitHub Logo" class="h-8 mb-2" />
             <span class="font-bold">View Source Code</span>
             GitHub Repository


### PR DESCRIPTION
Before, the stacked items aligned more to the left side.

**Before:**
![image](https://github.com/user-attachments/assets/c0e0e9b7-9fd2-4850-b2a7-82cc082e1f0f)

**After:**
![image](https://github.com/user-attachments/assets/c5540c40-3df9-49b0-924c-3f541231ee2a)
